### PR TITLE
.sort no longer exists for Lists as of scala 2.10.0

### DIFF
--- a/src/main/scala/org/saunter/bencode/Bencode.scala
+++ b/src/main/scala/org/saunter/bencode/Bencode.scala
@@ -131,7 +131,7 @@ object BencodeEncoder {
     "l" + input.map( x => encode(x)).mkString + "e"
 
   def dictionary(input: Map[String, _]): String =
-    "d" + input.toList.sort( (x,y) => x._1<y._1 ).map(
+    "d" + input.toList.sortWith( (x,y) => x._1<y._1 ).map(
       x => (string(x._1), encode(x._2))).flatMap(
         x => x._1 + x._2 ).mkString + "e"
 }


### PR DESCRIPTION
This was deprecated by 2.9 (and perhaps earlier -- I didn't check) and was removed in 2.10.0

Here's the warning I get with 2.9.2:
[warn] scala-bencode/src/main/scala/org/saunter/bencode/Bencode.scala:134: method sort in class List is deprecated: use `sortWith' instead
[warn]     "d" + input.toList.sort( (x,y) => x._1<y._1 ).map(
[warn]                        ^

And here's the error I get with 2.10.0:
[error] scala-bencode/src/main/scala/org/saunter/bencode/Bencode.scala:134: value sort is not a member of List[(String, Any)]
[error]     "d" + input.toList.sort( (x,y) => x._1<y._1 ).map(
[error]
